### PR TITLE
Remove Calendly Button

### DIFF
--- a/sections/contact.js
+++ b/sections/contact.js
@@ -2,7 +2,7 @@ import Section from '../components/section/section'
 import SectionHeading from '../components/section/sectionHeading'
 import SectionContent from '../components/section/sectionContent'
 // import FormContact from '../components/forms/formContact'
-import CalloutCalendly from '../components/callouts/calloutCalendly'
+// import CalloutCalendly from '../components/callouts/calloutCalendly'
 
 const Contact = () => (
   <Section id="contact">
@@ -13,7 +13,6 @@ const Contact = () => (
           <p>
           Let's talk about your project! 🤝<br/><br/>Send us an email at zyphr.form@gmail.com or book a timeslot and let us know what you have in mind.
           </p>
-          <CalloutCalendly url="https://calendly.com/zyphr-form/15min" text="Book a call on Calendly" />
         </SectionContent>
       </div>
 {/*      <div className="col-lg-6 col-md-12 col-sm-12">


### PR DESCRIPTION
Since the Calendly button does nothing, this commit removes it from the Contact Us section.

<img width="1226" alt="image" src="https://github.com/user-attachments/assets/576baceb-2d40-4970-b978-32bc80b0f850">
